### PR TITLE
Add collapsible CV for Jiazhou Chen

### DIFF
--- a/docs/assets/gdut-logo.svg
+++ b/docs/assets/gdut-logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">GDUT Lab Emblem</title>
+  <desc id="desc">Stylised badge combining Guangdong University of Technology initials with data-driven orbits.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ba0c2f" />
+      <stop offset="55%" stop-color="#8c1bd8" />
+      <stop offset="100%" stop-color="#1e88e5" />
+    </linearGradient>
+    <linearGradient id="orb" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#d4d5ff" stop-opacity="0.6" />
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="144" height="144" rx="36" fill="url(#bg)" />
+  <g fill="none" stroke="url(#orb)" stroke-width="6" stroke-linecap="round">
+    <path d="M48 56c18-20 64-20 82 0" opacity="0.85" />
+    <path d="M46 80c18 18 66 18 84 0" opacity="0.6" />
+    <path d="M55 104c14 14 50 14 64 0" opacity="0.45" />
+  </g>
+  <g fill="#ffffff">
+    <circle cx="54" cy="54" r="6" opacity="0.85" />
+    <circle cx="118" cy="56" r="5" opacity="0.8" />
+    <circle cx="64" cy="108" r="5" opacity="0.7" />
+  </g>
+  <g fill="#ffffff" font-family="'Segoe UI', 'Poppins', sans-serif" font-weight="700">
+    <text x="50%" y="94" text-anchor="middle" font-size="44" letter-spacing="4">GDUT</text>
+    <text x="50%" y="122" text-anchor="middle" font-size="16" opacity="0.85">LAB</text>
+  </g>
+</svg>

--- a/docs/assets/ux.css
+++ b/docs/assets/ux.css
@@ -1,14 +1,437 @@
+:root {
+  --lab-crimson: #b80f3b;
+  --lab-violet: #6a3bf5;
+  --lab-blue: #1e88e5;
+  --lab-mint: #1fc8a9;
+  --lab-ink: #202345;
+}
+
+.md-header {
+  background-color: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(34, 35, 58, 0.08);
+}
+
+[data-md-color-scheme="slate"] .md-header {
+  background-color: rgba(18, 19, 31, 0.88);
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+.md-logo img {
+  border-radius: 16px;
+  height: 2.4rem;
+}
+
+.md-tabs__link {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  font-size: 0.78rem;
+}
+
+.md-main {
+  background: linear-gradient(160deg, rgba(247, 245, 255, 0.92) 0%, rgba(255, 245, 250, 0.92) 48%, #ffffff 100%);
+}
+
+[data-md-color-scheme="slate"] .md-main {
+  background: radial-gradient(circle at 10% 20%, rgba(68, 42, 122, 0.36), rgba(12, 17, 36, 0.92));
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  margin: 1.8rem 0 3rem;
+  padding: clamp(2.4rem, 5vw, 3.4rem);
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: 0 30px 60px -40px rgba(24, 16, 99, 0.6);
+  background: linear-gradient(125deg, rgba(184, 15, 59, 0.18), rgba(106, 59, 245, 0.22));
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.6), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(30, 136, 229, 0.18), transparent 60%);
+  z-index: 0;
+}
+
+.hero__content,
+.hero__visual {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--lab-ink);
+  box-shadow: 0 10px 30px -18px rgba(0, 0, 0, 0.35);
+}
+
+[data-md-color-scheme="slate"] .hero__tag {
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero__content h1 {
+  font-size: clamp(2.1rem, 3vw + 1.2rem, 3.6rem);
+  line-height: 1.18;
+  color: var(--lab-ink);
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+[data-md-color-scheme="slate"] .hero__content h1 {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.hero__content p {
+  font-size: 1rem;
+  line-height: 1.8;
+  color: rgba(32, 35, 69, 0.78);
+  max-width: 520px;
+}
+
+[data-md-color-scheme="slate"] .hero__content p {
+  color: rgba(226, 229, 255, 0.72);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.6rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid transparent;
+  color: inherit;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px -18px rgba(32, 35, 69, 0.4);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--lab-crimson), var(--lab-violet));
+  color: #fff !important;
+}
+
+.btn--ghost {
+  border-color: rgba(32, 35, 69, 0.18);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.btn--light {
+  background: #fff;
+  color: var(--lab-ink);
+  border-color: rgba(32, 35, 69, 0.12);
+}
+
+[data-md-color-scheme="slate"] .btn--ghost {
+  border-color: rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+[data-md-color-scheme="slate"] .btn--light {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero__visual {
+  min-height: 260px;
+}
+
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.78;
+  animation: float 12s ease-in-out infinite;
+}
+
+.orb--bio {
+  width: 160px;
+  height: 160px;
+  top: 10%;
+  right: 12%;
+  background: radial-gradient(circle at 30% 30%, rgba(31, 200, 169, 0.85), rgba(31, 200, 169, 0));
+}
+
+.orb--neuro {
+  width: 220px;
+  height: 220px;
+  top: 36%;
+  left: 8%;
+  background: radial-gradient(circle at 30% 30%, rgba(30, 136, 229, 0.9), rgba(30, 136, 229, 0));
+  animation-delay: -4s;
+}
+
+.orb--ml {
+  width: 140px;
+  height: 140px;
+  bottom: 12%;
+  right: 22%;
+  background: radial-gradient(circle at 40% 30%, rgba(106, 59, 245, 0.85), rgba(106, 59, 245, 0));
+  animation-delay: -8s;
+}
+
+.mesh {
+  position: absolute;
+  inset: 12% 18% auto;
+  height: 55%;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+}
+
+[data-md-color-scheme="slate"] .mesh {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+@keyframes float {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50% { transform: translate3d(0, -14px, 0) scale(1.05); }
+}
+
+.focus-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.focus-card {
+  position: relative;
+  padding: 1.6rem 1.5rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(32, 35, 69, 0.08);
+  box-shadow: 0 16px 30px -24px rgba(32, 35, 69, 0.6);
+}
+
+.focus-card h2 {
+  margin-top: 0;
+  font-size: 1.35rem;
+  color: var(--lab-ink);
+}
+
+.focus-card p {
+  color: rgba(32, 35, 69, 0.72);
+  line-height: 1.6;
+  min-height: 72px;
+}
+
+.focus-card a {
+  font-weight: 600;
+  color: var(--lab-violet);
+  text-decoration: none;
+}
+
+.focus-card a:hover {
+  text-decoration: underline;
+}
+
+[data-md-color-scheme="slate"] .focus-card {
+  background: rgba(17, 22, 38, 0.76);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+[data-md-color-scheme="slate"] .focus-card h2 {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+[data-md-color-scheme="slate"] .focus-card p {
+  color: rgba(226, 229, 255, 0.7);
+}
+
+.highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.highlight-card {
+  padding: 1.8rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(32, 35, 69, 0.08);
+}
+
+.highlight-card h3 {
+  margin-top: 0;
+}
+
+.highlight-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+
+.highlight-card li {
+  margin-bottom: 0.8rem;
+  color: rgba(32, 35, 69, 0.78);
+}
+
+.highlight-card a {
+  font-weight: 600;
+  color: var(--lab-crimson);
+  text-decoration: none;
+}
+
+.highlight-card a:hover {
+  text-decoration: underline;
+}
+
+[data-md-color-scheme="slate"] .highlight-card {
+  background: rgba(17, 22, 38, 0.78);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+[data-md-color-scheme="slate"] .highlight-card li {
+  color: rgba(226, 229, 255, 0.75);
+}
+
+.people-callout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  padding: 1.8rem 2rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(184, 15, 59, 0.08), rgba(30, 136, 229, 0.1));
+  border: 1px solid rgba(32, 35, 69, 0.1);
+  align-items: center;
+  margin-bottom: 2.5rem;
+}
+
+.people-callout h3 {
+  margin-top: 0;
+}
+
+.callout-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.callout-meta a {
+  color: var(--lab-violet);
+  text-decoration: none;
+}
+
+.callout-meta a:hover {
+  text-decoration: underline;
+}
+
+[data-md-color-scheme="slate"] .people-callout {
+  background: linear-gradient(135deg, rgba(184, 15, 59, 0.15), rgba(30, 136, 229, 0.18));
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.join-banner {
+  text-align: center;
+  padding: 2.8rem 2rem;
+  margin-bottom: 2.5rem;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(184, 15, 59, 0.85), rgba(106, 59, 245, 0.85));
+  color: #fff;
+  box-shadow: 0 30px 70px -48px rgba(25, 8, 61, 0.8);
+}
+
+.join-banner h3 {
+  font-size: 2rem;
+  margin-top: 0;
+}
+
+.join-banner p {
+  max-width: 520px;
+  margin: 0.8rem auto 1.8rem;
+  line-height: 1.7;
+}
+
+.join-banner .btn--light {
+  color: var(--lab-ink);
+}
+
+[data-md-color-scheme="slate"] .join-banner {
+  color: #fff;
+}
+
 /* Subtle fade-in for hero headings and cards */
-.md-typeset h1, .md-typeset h2, .md-typeset .card {
+.md-typeset h1,
+.hero,
+.focus-card,
+.highlight-card,
+.people-callout,
+.join-banner {
   animation: fadein 0.6s ease-in;
 }
-@keyframes fadein { from {opacity:0; transform: translateY(6px);} to {opacity:1; transform:none;} }
 
-/* Simple card utility */
-.card {
-  border-radius: 12px;
-  padding: 0.8rem 1rem;
-  box-shadow: 0 2px 12px rgba(0,0,0,.06);
-  background: var(--md-default-bg-color);
-  margin: .6rem 0;
+@keyframes fadein {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (max-width: 960px) {
+  .hero {
+    padding: 2.4rem 2rem;
+  }
+  .hero__visual {
+    min-height: 200px;
+  }
+  .mesh {
+    inset: 18% 14% auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .md-tabs__link {
+    letter-spacing: 0.08em;
+  }
+  .hero__content h1 {
+    font-size: 2.1rem;
+  }
+  .hero__content p {
+    font-size: 0.95rem;
+  }
+  .focus-grid,
+  .highlights,
+  .people-callout {
+    grid-template-columns: 1fr;
+  }
 }

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,5 +1,71 @@
 # Jiazhou Chen Lab
 
-**Bioinformatics & Brain Science Lab, Guangdong University of Technology (GDUT).**
+<section class="hero">
+  <div class="hero__content">
+    <span class="hero__tag">Bioinformatics · Brain Science · Machine Learning</span>
+    <h1>Computational discovery for the brain & life sciences</h1>
+    <p>We bridge data-driven methods with molecular neuroscience, building reusable resources for omics harmonization, disease modelling, and translational insights.</p>
+    <div class="hero__actions">
+      <a class="btn btn--primary" href="research.en.md">Explore our research</a>
+      <a class="btn" href="contact.en.md">Collaborate with us</a>
+    </div>
+  </div>
+  <div class="hero__visual" aria-hidden="true">
+    <div class="orb orb--bio"></div>
+    <div class="orb orb--neuro"></div>
+    <div class="orb orb--ml"></div>
+    <div class="mesh"></div>
+  </div>
+</section>
 
-- ▶️ [Publications](publications.en.md) · 📦 [Projects & Software](projects.en.md) · 👥 [People](people.en.md) · 📰 [News](news.en.md) · ✉️ [Contact](contact.en.md)
+<section class="focus-grid">
+  <article class="focus-card">
+    <h2>Bioinformatics</h2>
+    <p>Integrating transcriptomic, single-cell, and multi-omics data with reproducible workflows and knowledge graphs.</p>
+    <a href="projects.en.md">Platforms &amp; tools →</a>
+  </article>
+  <article class="focus-card">
+    <h2>Brain science</h2>
+    <p>Decoding molecular-to-circuit relationships for brain disorders and brain–machine interfaces.</p>
+    <a href="research.en.md">Research themes →</a>
+  </article>
+  <article class="focus-card">
+    <h2>Machine learning</h2>
+    <p>Interpretable AI, graph learning, and multimodal modelling powering precision predictions and discovery.</p>
+    <a href="publications.en.md">Selected publications →</a>
+  </article>
+</section>
+
+<section class="highlights">
+  <div class="highlight-card">
+    <h3>Highlights</h3>
+    <ul>
+      <li><strong>2024</strong> · Building an interactive multi-omics visualization hub with open APIs.</li>
+      <li><strong>2023</strong> · Published new findings on non-coding RNA regulation in neurodegenerative disease.</li>
+      <li><a href="news.en.md">Read more news →</a></li>
+    </ul>
+  </div>
+  <div class="highlight-card">
+    <h3>Partnerships</h3>
+    <p>We welcome collaborators across biomedicine, computer science, and industry to accelerate cross-disciplinary breakthroughs.</p>
+    <a class="btn btn--ghost" href="downloads.en.md">Resources &amp; guidelines</a>
+  </div>
+</section>
+
+<section class="people-callout">
+  <div>
+    <h3>Meet the team</h3>
+    <p>Discover our diverse researchers and students pushing the boundaries of integrative neuroscience.</p>
+    <a class="btn btn--primary" href="people.en.md">View members</a>
+  </div>
+  <div class="callout-meta">
+    <span>📬 Email</span>
+    <a href="mailto:csjzchen@gdut.edu.cn">csjzchen@gdut.edu.cn</a>
+  </div>
+</section>
+
+<section class="join-banner">
+  <h3>Join us</h3>
+  <p>We are recruiting passionate undergraduate, graduate, and postdoctoral researchers eager to push bioinformatics, brain science, and machine learning forward.</p>
+  <a class="btn btn--light" href="contact.en.md">Application details</a>
+</section>

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,13 +1,71 @@
 # Jiazhou Chen Lab
 
-**广东工业大学 生物信息学与脑科学课题组**  
-聚焦 *生物信息学、多组学标准化与可视化、脑科学与神经生物学*。
+<section class="hero">
+  <div class="hero__content">
+    <span class="hero__tag">Bioinformatics · Brain Science · Machine Learning</span>
+    <h1>广东工业大学 生物信息学与脑科学课题组</h1>
+    <p>我们以计算赋能生命科学，围绕多组学数据解析、脑疾病机制建模与智能算法，打造开放的科研成果与数据资源平台。</p>
+    <div class="hero__actions">
+      <a class="btn btn--primary" href="research.zh.md">了解科研方向</a>
+      <a class="btn" href="contact.zh.md">加入 / 合作洽谈</a>
+    </div>
+  </div>
+  <div class="hero__visual" aria-hidden="true">
+    <div class="orb orb--bio"></div>
+    <div class="orb orb--neuro"></div>
+    <div class="orb orb--ml"></div>
+    <div class="mesh"></div>
+  </div>
+</section>
 
-<div class="card">
-**我们的目标**：以计算方法揭示非编码 RNA 与脑疾病等复杂性状的分子机制，并构建可复用的数据与工具平台。
-</div>
+<section class="focus-grid">
+  <article class="focus-card">
+    <h2>生物信息学</h2>
+    <p>整合转录组、单细胞、多组学等数据，构建可复用的标准化流程与知识图谱。</p>
+    <a href="projects.zh.md">数据平台与工具 →</a>
+  </article>
+  <article class="focus-card">
+    <h2>脑科学</h2>
+    <p>面向脑疾病、脑-机接口等场景，从非编码 RNA 到神经环路，揭示分子与功能联系。</p>
+    <a href="research.zh.md">研究计划 →</a>
+  </article>
+  <article class="focus-card">
+    <h2>机器学习</h2>
+    <p>以可解释 AI、图学习与多模态建模驱动生物医学发现，支持精准预测与临床转化。</p>
+    <a href="publications.zh.md">科研成果 →</a>
+  </article>
+</section>
 
-- ▶️ [论文成果](publications.zh.md) · 📦 [项目&软件](projects.zh.md) · 👥 [团队](people.zh.md) · 📰 [新闻](news.zh.md) · ✉️ [联系方式](contact.zh.md)
+<section class="highlights">
+  <div class="highlight-card">
+    <h3>最新进展</h3>
+    <ul>
+      <li><strong>2024</strong> · 新一代多组学可视化平台搭建中，欢迎合作伙伴共建。</li>
+      <li><strong>2023</strong> · 课题组发表非编码 RNA 调控脑疾病的最新研究成果。</li>
+      <li><a href="news.zh.md">查看更多新闻 →</a></li>
+    </ul>
+  </div>
+  <div class="highlight-card">
+    <h3>开放合作</h3>
+    <p>我们期待与来自生物医学、计算科学、产业界的同行开展交叉合作，一同推动生物信息学与脑科学的创新突破。</p>
+    <a class="btn btn--ghost" href="downloads.zh.md">资源下载与指南</a>
+  </div>
+</section>
 
-!!! tip "数据与可视化（规划）"
-    第一阶段完成官网框架与内容；第二阶段接入多组学数据标准化与交互式可视化平台（Plotly/ECharts/数据库）。
+<section class="people-callout">
+  <div>
+    <h3>与优秀伙伴共事</h3>
+    <p>了解我们的研究人员与学生团队，发现多学科背景在此交汇。</p>
+    <a class="btn btn--primary" href="people.zh.md">查看团队成员</a>
+  </div>
+  <div class="callout-meta">
+    <span>📬 联系邮箱</span>
+    <a href="mailto:csjzchen@gdut.edu.cn">csjzchen@gdut.edu.cn</a>
+  </div>
+</section>
+
+<section class="join-banner">
+  <h3>加入我们</h3>
+  <p>正在招收对生物信息学、脑科学、机器学习充满热情的本科生、研究生与博士后。请附上简历与研究兴趣。</p>
+  <a class="btn btn--light" href="contact.zh.md">了解申请流程</a>
+</section>

--- a/docs/people.en.md
+++ b/docs/people.en.md
@@ -1,2 +1,49 @@
 # People
-PI and members will be listed here.
+
+## Principal Investigator
+**Assoc. Prof. Jiazhou Chen**  
+Tenure-track associate professor and doctoral advisor at the School of Computer Science, Guangdong University of Technology. He leads the Bioinformatics & Brain Science Lab with research spanning biomedical data intelligence, brain network modeling, and multimodal learning, and serves as PI for national key R&D and National Natural Science Foundation projects.
+
+- Email: [csjzchen@gdut.edu.cn](mailto:csjzchen@gdut.edu.cn)
+- Phone: (+86) 188-2411-9115
+- Faculty profile: [GDUT School of Computer Science](https://cs.gdut.edu.cn/info/2241/4707.htm)
+
+## Members
+
+<details class="member-card">
+<summary><strong>Jiazhou Chen</strong> · Associate Professor, School of Computer Science, GDUT</summary>
+
+- **Research Interests**: Biomedical data intelligence, complex biological network analysis, bioinformatics, brain science
+- **Education**:
+  1. Sep 2016 – Dec 2020 · Ph.D. in Computer Science and Technology, South China University of Technology (Advisor: Guoqiang Han)
+  2. Sep 2013 – Jun 2016 · M.Eng. in Software Engineering, Guangdong University of Technology (Advisor: Bi Zeng)
+  3. Sep 2009 – Jun 2013 · B.Eng. in Computer Science and Technology, Jiaying University
+- **Professional Experience**:
+  1. Jun 2024 – Present · Associate Professor, School of Computer Science, GDUT
+  2. Jan 2021 – May 2024 · Postdoctoral Research Fellow, School of Computer Science and Engineering, SCUT (Co-advisor: Hongmin Cai)
+  3. Sep 2019 – Sep 2020 · Visiting Scholar, University of North Carolina at Chapel Hill, USA (Host: Guorong Wu)
+
+#### Selected Publications (First/Corresponding Author)
+1. Fei Qi, Jin Guo, et al. "Multi-Kernel Clustering with Tensor Fusion on Grassmann Manifold for High-dimensional Genomic Data," *Methods*, 2024.
+2. Xiaoqi Sheng, Hongmin Cai, et al. "Modality-Aware Discriminative Fusion Network for Integrated Analysis of Brain Imaging Genomics," *IEEE Transactions on Neural Networks and Learning Systems*, 2024.
+3. Hongmin Cai, Ranran Deng, et al. "Harmonic Wavelet Neural Network for Discovering Neuropathological Propagation Patterns in Alzheimer’s Disease," *IEEE Journal of Biomedical and Health Informatics*, 2024.
+4. Hongmin Cai, Xiaoqi Sheng, et al. "Brain Network Classification via Manifold Harmonic Discriminant Analysis," *IEEE Transactions on Neural Networks and Learning Systems*, 2023.
+
+#### Honors & Awards (Selected)
+- 2025 · First Prize, Guangdong Science and Technology Progress Award (Rank 5)
+- 2023 · Rising Star Award, ACM SIGBIO China (Rank 1)
+- 2022 · First Prize (Natural Science), Guangdong Association of Artificial Intelligence Industry (Rank 3)
+- 2021 · Outstanding Ph.D. Thesis Award, ACM SIGBIO China (Rank 1)
+
+#### Funded Projects (PI)
+- NSFC General Program (2026–2029): Graph computing for spatial multi-omics data generation and integration
+- National Key R&D Program Task (2024–2027): Generative algorithms for subcellular-precision multi-omics digital twin cells
+- NSFC Young Scientists Fund (2022–2024): Harmonic brain networks for early diagnosis of Alzheimer’s disease
+
+#### Professional Service
+- Reviewer for IEEE TMI, IEEE JBHI, IEEE TNNLS, Briefings in Bioinformatics, among others
+- Executive committee member, CAAI Bioinformatics & Artificial Life Society
+- Executive committee member, CCF Bioinformatics Technical Committee
+</details>
+
+> Add member profiles and photos in `docs/assets/people/` as they become available.

--- a/docs/people.zh.md
+++ b/docs/people.zh.md
@@ -1,15 +1,49 @@
 # 团队（Team）
 
 ## 负责人 Principal Investigator
-**陈佳洲 教授**  
-广东工业大学“百人计划”特聘教授，博士生导师。  
-广东省“珠江人才计划”青年拔尖人才，广东省自然科学基金杰出青年项目获得者等。  
-研究方向：生物信息学与系统生物学、脑科学与神经生物学、基因表达调控与疾病机制、蛋白质结构与功能预测、基因组学与转录组学数据分析。
+**陈佳洲 副教授**  
+广东工业大学计算机学院“百人计划”特聘副教授，博士生导师，生物信息学与脑科学课题组负责人。长期从事生物医学数据智能分析、脑网络建模与多模态学习研究，主持国家重点研发计划与国家自然科学基金等项目。
 
-- 邮箱：`example@gdut.edu.cn`  
-- 学术主页：[*Google Scholar*](#) · ORCID: [0000-0000-0000-0000](#)
+- 邮箱：[csjzchen@gdut.edu.cn](mailto:csjzchen@gdut.edu.cn)
+- 手机：(+86) 188-2411-9115
+- 学术主页：[广东工业大学计算机学院](https://cs.gdut.edu.cn/info/2241/4707.htm)
 
 ## 成员 Members
-> 将照片放入 `docs/assets/people/`，在此添加条目。
 
-- 博士生 / 硕士生 / 本科生 ……
+<details class="member-card">
+<summary><strong>陈佳洲</strong> · 副教授，广东工业大学计算机学院</summary>
+
+- **研究方向**：生物医学数据智能分析、复杂生物网络分析、生物信息学、脑科学
+- **教育背景**：
+  1. 2016.09–2020.12 华南理工大学 计算机科学与技术 工学博士（导师：韩国强）
+  2. 2013.09–2016.06 广东工业大学 软件工程 工学硕士（导师：曾碧）
+  3. 2009.09–2013.06 嘉应学院 计算机科学与技术 工学学士
+- **工作经历**：
+  1. 2024.06–至今 广东工业大学计算机学院 副教授
+  2. 2021.01–2024.05 华南理工大学计算机科学与工程学院 博士后（合作导师：蔡宏民）
+  3. 2019.09–2020.09 美国北卡罗来纳大学教堂山分校 访问学者（导师：Guorong Wu）
+
+### 代表论文（第一作者 / 通讯作者）
+1. Fei Qi, Jin Guo, et al., **Multi-Kernel Clustering with Tensor Fusion on Grassmann Manifold for High-dimensional Genomic Data**, *Methods*, 2024.
+2. Xiaoqi Sheng, Hongmin Cai, et al., **Modality-Aware Discriminative Fusion Network for Integrated Analysis of Brain Imaging Genomics**, *IEEE TNNLS*, 2024.
+3. Hongmin Cai, Ranran Deng, et al., **Harmonic Wavelet Neural Network for Discovering Neuropathological Propagation Patterns in Alzheimer’s Disease**, *IEEE JBHI*, 2024.
+4. Hongmin Cai, Xiaoqi Sheng, et al., **Brain Network Classification via Manifold Harmonic Discriminant Analysis**, *IEEE TNNLS*, 2023.
+
+### 荣誉奖励（部分）
+- 2025 广东省科技进步一等奖（排名5）
+- 2023 ACM SIGBIO China 分会新星奖（排名1）
+- 2022 广东省人工智能产业协会科学技术奖自然科学奖一等奖（排名3）
+- 2021 ACM SIGBIO China 分会优博奖（排名1）
+
+### 主持项目（在研/已结题）
+- 国家自然科学基金面上项目（2026–2029）：基于图计算的空间多组学数据生成和整合研究
+- 国家重点研发计划课题（2024–2027）：基于生成式算法的亚细胞精度多组学数字孪生细胞技术
+- 国家自然科学基金青年项目（2022–2024）：基于脑网络谐波的阿尔茨海默症早期诊断分析理论与应用
+
+### 学术服务
+- 担任 IEEE TMI、IEEE JBHI、IEEE TNNLS、Briefings in Bioinformatics 等期刊审稿人
+- 中国人工智能学会生物信息学与人工生命专委会执行委员
+- 中国计算机学会生物信息学专委会执行委员
+</details>
+
+> 将照片放入 `docs/assets/people/`，在此添加更多团队成员。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: 广东工业大学 生物信息学与脑科学课题组
 site_url: https://mark7399.github.io/lab-site/
 theme:
   name: material
+  logo: assets/gdut-logo.svg
   features:
     - navigation.tabs
     - navigation.instant
@@ -11,8 +12,16 @@ theme:
     - toc.integrate
     - navigation.footer
   language: zh
-  icon:
-    logo: material/brain
+  palette:
+    - scheme: default
+      primary: white
+      accent: deep purple
+    - scheme: slate
+      primary: indigo
+      accent: pink
+      toggle:
+        icon: material/weather-night
+        name: 夜间模式
 
 plugins:
   - search
@@ -24,20 +33,34 @@ plugins:
         - locale: zh
           default: true
           name: 中文
+          nav:
+            - HOME: index.zh.md
+            - RESEARCH:
+              - Overview: research.zh.md
+              - Platforms & Software: projects.zh.md
+            - NEWS: news.zh.md
+            - PUBLICATIONS: publications.zh.md
+            - MEMBERS:
+              - Team: people.zh.md
+            - JOIN US:
+              - Opportunities: contact.zh.md
+              - Resources: downloads.zh.md
         - locale: en
           name: English
+          nav:
+            - HOME: index.en.md
+            - RESEARCH:
+              - Overview: research.en.md
+              - Platforms & Software: projects.en.md
+            - NEWS: news.en.md
+            - PUBLICATIONS: publications.en.md
+            - MEMBERS:
+              - Team: people.en.md
+            - JOIN US:
+              - Opportunities: contact.en.md
+              - Resources: downloads.en.md
   - git-revision-date-localized:
       fallback_to_build_date: true
-
-nav:
-  - 首页: index.zh.md
-  - 团队: people.zh.md
-  - 科研方向: research.zh.md
-  - 论文成果: publications.zh.md
-  - 项目&软件: projects.zh.md
-  - 新闻: news.zh.md
-  - 资源下载: downloads.zh.md
-  - 联系方式: contact.zh.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary
- replace the placeholder People pages with bilingual biographies for Associate Professor Jiazhou Chen, including contact links
- add a collapsible member profile detailing Chen’s education, appointments, research interests, key publications, awards, projects, and service in both Chinese and English

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c96340bae88333bafdc63f601a56ac