### PR TITLE
Curate Chen Jiazhou CV content

### DIFF
--- a/docs/assets/gdut-logo.svg
+++ b/docs/assets/gdut-logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">GDUT Lab Emblem</title>
+  <desc id="desc">Stylised badge combining Guangdong University of Technology initials with data-driven orbits.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ba0c2f" />
+      <stop offset="55%" stop-color="#8c1bd8" />
+      <stop offset="100%" stop-color="#1e88e5" />
+    </linearGradient>
+    <linearGradient id="orb" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#d4d5ff" stop-opacity="0.6" />
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="144" height="144" rx="36" fill="url(#bg)" />
+  <g fill="none" stroke="url(#orb)" stroke-width="6" stroke-linecap="round">
+    <path d="M48 56c18-20 64-20 82 0" opacity="0.85" />
+    <path d="M46 80c18 18 66 18 84 0" opacity="0.6" />
+    <path d="M55 104c14 14 50 14 64 0" opacity="0.45" />
+  </g>
+  <g fill="#ffffff">
+    <circle cx="54" cy="54" r="6" opacity="0.85" />
+    <circle cx="118" cy="56" r="5" opacity="0.8" />
+    <circle cx="64" cy="108" r="5" opacity="0.7" />
+  </g>
+  <g fill="#ffffff" font-family="'Segoe UI', 'Poppins', sans-serif" font-weight="700">
+    <text x="50%" y="94" text-anchor="middle" font-size="44" letter-spacing="4">GDUT</text>
+    <text x="50%" y="122" text-anchor="middle" font-size="16" opacity="0.85">LAB</text>
+  </g>
+</svg>

--- a/docs/assets/ux.css
+++ b/docs/assets/ux.css
@@ -1,14 +1,437 @@
+:root {
+  --lab-crimson: #b80f3b;
+  --lab-violet: #6a3bf5;
+  --lab-blue: #1e88e5;
+  --lab-mint: #1fc8a9;
+  --lab-ink: #202345;
+}
+
+.md-header {
+  background-color: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(34, 35, 58, 0.08);
+}
+
+[data-md-color-scheme="slate"] .md-header {
+  background-color: rgba(18, 19, 31, 0.88);
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+.md-logo img {
+  border-radius: 16px;
+  height: 2.4rem;
+}
+
+.md-tabs__link {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  font-size: 0.78rem;
+}
+
+.md-main {
+  background: linear-gradient(160deg, rgba(247, 245, 255, 0.92) 0%, rgba(255, 245, 250, 0.92) 48%, #ffffff 100%);
+}
+
+[data-md-color-scheme="slate"] .md-main {
+  background: radial-gradient(circle at 10% 20%, rgba(68, 42, 122, 0.36), rgba(12, 17, 36, 0.92));
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  margin: 1.8rem 0 3rem;
+  padding: clamp(2.4rem, 5vw, 3.4rem);
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: 0 30px 60px -40px rgba(24, 16, 99, 0.6);
+  background: linear-gradient(125deg, rgba(184, 15, 59, 0.18), rgba(106, 59, 245, 0.22));
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.6), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(30, 136, 229, 0.18), transparent 60%);
+  z-index: 0;
+}
+
+.hero__content,
+.hero__visual {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--lab-ink);
+  box-shadow: 0 10px 30px -18px rgba(0, 0, 0, 0.35);
+}
+
+[data-md-color-scheme="slate"] .hero__tag {
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero__content h1 {
+  font-size: clamp(2.1rem, 3vw + 1.2rem, 3.6rem);
+  line-height: 1.18;
+  color: var(--lab-ink);
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+[data-md-color-scheme="slate"] .hero__content h1 {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.hero__content p {
+  font-size: 1rem;
+  line-height: 1.8;
+  color: rgba(32, 35, 69, 0.78);
+  max-width: 520px;
+}
+
+[data-md-color-scheme="slate"] .hero__content p {
+  color: rgba(226, 229, 255, 0.72);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.6rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid transparent;
+  color: inherit;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px -18px rgba(32, 35, 69, 0.4);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--lab-crimson), var(--lab-violet));
+  color: #fff !important;
+}
+
+.btn--ghost {
+  border-color: rgba(32, 35, 69, 0.18);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.btn--light {
+  background: #fff;
+  color: var(--lab-ink);
+  border-color: rgba(32, 35, 69, 0.12);
+}
+
+[data-md-color-scheme="slate"] .btn--ghost {
+  border-color: rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+[data-md-color-scheme="slate"] .btn--light {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero__visual {
+  min-height: 260px;
+}
+
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.78;
+  animation: float 12s ease-in-out infinite;
+}
+
+.orb--bio {
+  width: 160px;
+  height: 160px;
+  top: 10%;
+  right: 12%;
+  background: radial-gradient(circle at 30% 30%, rgba(31, 200, 169, 0.85), rgba(31, 200, 169, 0));
+}
+
+.orb--neuro {
+  width: 220px;
+  height: 220px;
+  top: 36%;
+  left: 8%;
+  background: radial-gradient(circle at 30% 30%, rgba(30, 136, 229, 0.9), rgba(30, 136, 229, 0));
+  animation-delay: -4s;
+}
+
+.orb--ml {
+  width: 140px;
+  height: 140px;
+  bottom: 12%;
+  right: 22%;
+  background: radial-gradient(circle at 40% 30%, rgba(106, 59, 245, 0.85), rgba(106, 59, 245, 0));
+  animation-delay: -8s;
+}
+
+.mesh {
+  position: absolute;
+  inset: 12% 18% auto;
+  height: 55%;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+}
+
+[data-md-color-scheme="slate"] .mesh {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+@keyframes float {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50% { transform: translate3d(0, -14px, 0) scale(1.05); }
+}
+
+.focus-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.focus-card {
+  position: relative;
+  padding: 1.6rem 1.5rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(32, 35, 69, 0.08);
+  box-shadow: 0 16px 30px -24px rgba(32, 35, 69, 0.6);
+}
+
+.focus-card h2 {
+  margin-top: 0;
+  font-size: 1.35rem;
+  color: var(--lab-ink);
+}
+
+.focus-card p {
+  color: rgba(32, 35, 69, 0.72);
+  line-height: 1.6;
+  min-height: 72px;
+}
+
+.focus-card a {
+  font-weight: 600;
+  color: var(--lab-violet);
+  text-decoration: none;
+}
+
+.focus-card a:hover {
+  text-decoration: underline;
+}
+
+[data-md-color-scheme="slate"] .focus-card {
+  background: rgba(17, 22, 38, 0.76);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+[data-md-color-scheme="slate"] .focus-card h2 {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+[data-md-color-scheme="slate"] .focus-card p {
+  color: rgba(226, 229, 255, 0.7);
+}
+
+.highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.highlight-card {
+  padding: 1.8rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(32, 35, 69, 0.08);
+}
+
+.highlight-card h3 {
+  margin-top: 0;
+}
+
+.highlight-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+
+.highlight-card li {
+  margin-bottom: 0.8rem;
+  color: rgba(32, 35, 69, 0.78);
+}
+
+.highlight-card a {
+  font-weight: 600;
+  color: var(--lab-crimson);
+  text-decoration: none;
+}
+
+.highlight-card a:hover {
+  text-decoration: underline;
+}
+
+[data-md-color-scheme="slate"] .highlight-card {
+  background: rgba(17, 22, 38, 0.78);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+[data-md-color-scheme="slate"] .highlight-card li {
+  color: rgba(226, 229, 255, 0.75);
+}
+
+.people-callout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  padding: 1.8rem 2rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(184, 15, 59, 0.08), rgba(30, 136, 229, 0.1));
+  border: 1px solid rgba(32, 35, 69, 0.1);
+  align-items: center;
+  margin-bottom: 2.5rem;
+}
+
+.people-callout h3 {
+  margin-top: 0;
+}
+
+.callout-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.callout-meta a {
+  color: var(--lab-violet);
+  text-decoration: none;
+}
+
+.callout-meta a:hover {
+  text-decoration: underline;
+}
+
+[data-md-color-scheme="slate"] .people-callout {
+  background: linear-gradient(135deg, rgba(184, 15, 59, 0.15), rgba(30, 136, 229, 0.18));
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.join-banner {
+  text-align: center;
+  padding: 2.8rem 2rem;
+  margin-bottom: 2.5rem;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(184, 15, 59, 0.85), rgba(106, 59, 245, 0.85));
+  color: #fff;
+  box-shadow: 0 30px 70px -48px rgba(25, 8, 61, 0.8);
+}
+
+.join-banner h3 {
+  font-size: 2rem;
+  margin-top: 0;
+}
+
+.join-banner p {
+  max-width: 520px;
+  margin: 0.8rem auto 1.8rem;
+  line-height: 1.7;
+}
+
+.join-banner .btn--light {
+  color: var(--lab-ink);
+}
+
+[data-md-color-scheme="slate"] .join-banner {
+  color: #fff;
+}
+
 /* Subtle fade-in for hero headings and cards */
-.md-typeset h1, .md-typeset h2, .md-typeset .card {
+.md-typeset h1,
+.hero,
+.focus-card,
+.highlight-card,
+.people-callout,
+.join-banner {
   animation: fadein 0.6s ease-in;
 }
-@keyframes fadein { from {opacity:0; transform: translateY(6px);} to {opacity:1; transform:none;} }
 
-/* Simple card utility */
-.card {
-  border-radius: 12px;
-  padding: 0.8rem 1rem;
-  box-shadow: 0 2px 12px rgba(0,0,0,.06);
-  background: var(--md-default-bg-color);
-  margin: .6rem 0;
+@keyframes fadein {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (max-width: 960px) {
+  .hero {
+    padding: 2.4rem 2rem;
+  }
+  .hero__visual {
+    min-height: 200px;
+  }
+  .mesh {
+    inset: 18% 14% auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .md-tabs__link {
+    letter-spacing: 0.08em;
+  }
+  .hero__content h1 {
+    font-size: 2.1rem;
+  }
+  .hero__content p {
+    font-size: 0.95rem;
+  }
+  .focus-grid,
+  .highlights,
+  .people-callout {
+    grid-template-columns: 1fr;
+  }
 }

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,5 +1,71 @@
 # Jiazhou Chen Lab
 
-**Bioinformatics & Brain Science Lab, Guangdong University of Technology (GDUT).**
+<section class="hero">
+  <div class="hero__content">
+    <span class="hero__tag">Bioinformatics · Brain Science · Machine Learning</span>
+    <h1>Computational discovery for the brain & life sciences</h1>
+    <p>We bridge data-driven methods with molecular neuroscience, building reusable resources for omics harmonization, disease modelling, and translational insights.</p>
+    <div class="hero__actions">
+      <a class="btn btn--primary" href="research.en.md">Explore our research</a>
+      <a class="btn" href="contact.en.md">Collaborate with us</a>
+    </div>
+  </div>
+  <div class="hero__visual" aria-hidden="true">
+    <div class="orb orb--bio"></div>
+    <div class="orb orb--neuro"></div>
+    <div class="orb orb--ml"></div>
+    <div class="mesh"></div>
+  </div>
+</section>
 
-- ▶️ [Publications](publications.en.md) · 📦 [Projects & Software](projects.en.md) · 👥 [People](people.en.md) · 📰 [News](news.en.md) · ✉️ [Contact](contact.en.md)
+<section class="focus-grid">
+  <article class="focus-card">
+    <h2>Bioinformatics</h2>
+    <p>Integrating transcriptomic, single-cell, and multi-omics data with reproducible workflows and knowledge graphs.</p>
+    <a href="projects.en.md">Platforms &amp; tools →</a>
+  </article>
+  <article class="focus-card">
+    <h2>Brain science</h2>
+    <p>Decoding molecular-to-circuit relationships for brain disorders and brain–machine interfaces.</p>
+    <a href="research.en.md">Research themes →</a>
+  </article>
+  <article class="focus-card">
+    <h2>Machine learning</h2>
+    <p>Interpretable AI, graph learning, and multimodal modelling powering precision predictions and discovery.</p>
+    <a href="publications.en.md">Selected publications →</a>
+  </article>
+</section>
+
+<section class="highlights">
+  <div class="highlight-card">
+    <h3>Highlights</h3>
+    <ul>
+      <li><strong>2024</strong> · Building an interactive multi-omics visualization hub with open APIs.</li>
+      <li><strong>2023</strong> · Published new findings on non-coding RNA regulation in neurodegenerative disease.</li>
+      <li><a href="news.en.md">Read more news →</a></li>
+    </ul>
+  </div>
+  <div class="highlight-card">
+    <h3>Partnerships</h3>
+    <p>We welcome collaborators across biomedicine, computer science, and industry to accelerate cross-disciplinary breakthroughs.</p>
+    <a class="btn btn--ghost" href="downloads.en.md">Resources &amp; guidelines</a>
+  </div>
+</section>
+
+<section class="people-callout">
+  <div>
+    <h3>Meet the team</h3>
+    <p>Discover our diverse researchers and students pushing the boundaries of integrative neuroscience.</p>
+    <a class="btn btn--primary" href="people.en.md">View members</a>
+  </div>
+  <div class="callout-meta">
+    <span>📬 Email</span>
+    <a href="mailto:csjzchen@gdut.edu.cn">csjzchen@gdut.edu.cn</a>
+  </div>
+</section>
+
+<section class="join-banner">
+  <h3>Join us</h3>
+  <p>We are recruiting passionate undergraduate, graduate, and postdoctoral researchers eager to push bioinformatics, brain science, and machine learning forward.</p>
+  <a class="btn btn--light" href="contact.en.md">Application details</a>
+</section>

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,13 +1,71 @@
 # Jiazhou Chen Lab
 
-**广东工业大学 生物信息学与脑科学课题组**  
-聚焦 *生物信息学、多组学标准化与可视化、脑科学与神经生物学*。
+<section class="hero">
+  <div class="hero__content">
+    <span class="hero__tag">Bioinformatics · Brain Science · Machine Learning</span>
+    <h1>广东工业大学 生物信息学与脑科学课题组</h1>
+    <p>我们以计算赋能生命科学，围绕多组学数据解析、脑疾病机制建模与智能算法，打造开放的科研成果与数据资源平台。</p>
+    <div class="hero__actions">
+      <a class="btn btn--primary" href="research.zh.md">了解科研方向</a>
+      <a class="btn" href="contact.zh.md">加入 / 合作洽谈</a>
+    </div>
+  </div>
+  <div class="hero__visual" aria-hidden="true">
+    <div class="orb orb--bio"></div>
+    <div class="orb orb--neuro"></div>
+    <div class="orb orb--ml"></div>
+    <div class="mesh"></div>
+  </div>
+</section>
 
-<div class="card">
-**我们的目标**：以计算方法揭示非编码 RNA 与脑疾病等复杂性状的分子机制，并构建可复用的数据与工具平台。
-</div>
+<section class="focus-grid">
+  <article class="focus-card">
+    <h2>生物信息学</h2>
+    <p>整合转录组、单细胞、多组学等数据，构建可复用的标准化流程与知识图谱。</p>
+    <a href="projects.zh.md">数据平台与工具 →</a>
+  </article>
+  <article class="focus-card">
+    <h2>脑科学</h2>
+    <p>面向脑疾病、脑-机接口等场景，从非编码 RNA 到神经环路，揭示分子与功能联系。</p>
+    <a href="research.zh.md">研究计划 →</a>
+  </article>
+  <article class="focus-card">
+    <h2>机器学习</h2>
+    <p>以可解释 AI、图学习与多模态建模驱动生物医学发现，支持精准预测与临床转化。</p>
+    <a href="publications.zh.md">科研成果 →</a>
+  </article>
+</section>
 
-- ▶️ [论文成果](publications.zh.md) · 📦 [项目&软件](projects.zh.md) · 👥 [团队](people.zh.md) · 📰 [新闻](news.zh.md) · ✉️ [联系方式](contact.zh.md)
+<section class="highlights">
+  <div class="highlight-card">
+    <h3>最新进展</h3>
+    <ul>
+      <li><strong>2024</strong> · 新一代多组学可视化平台搭建中，欢迎合作伙伴共建。</li>
+      <li><strong>2023</strong> · 课题组发表非编码 RNA 调控脑疾病的最新研究成果。</li>
+      <li><a href="news.zh.md">查看更多新闻 →</a></li>
+    </ul>
+  </div>
+  <div class="highlight-card">
+    <h3>开放合作</h3>
+    <p>我们期待与来自生物医学、计算科学、产业界的同行开展交叉合作，一同推动生物信息学与脑科学的创新突破。</p>
+    <a class="btn btn--ghost" href="downloads.zh.md">资源下载与指南</a>
+  </div>
+</section>
 
-!!! tip "数据与可视化（规划）"
-    第一阶段完成官网框架与内容；第二阶段接入多组学数据标准化与交互式可视化平台（Plotly/ECharts/数据库）。
+<section class="people-callout">
+  <div>
+    <h3>与优秀伙伴共事</h3>
+    <p>了解我们的研究人员与学生团队，发现多学科背景在此交汇。</p>
+    <a class="btn btn--primary" href="people.zh.md">查看团队成员</a>
+  </div>
+  <div class="callout-meta">
+    <span>📬 联系邮箱</span>
+    <a href="mailto:csjzchen@gdut.edu.cn">csjzchen@gdut.edu.cn</a>
+  </div>
+</section>
+
+<section class="join-banner">
+  <h3>加入我们</h3>
+  <p>正在招收对生物信息学、脑科学、机器学习充满热情的本科生、研究生与博士后。请附上简历与研究兴趣。</p>
+  <a class="btn btn--light" href="contact.zh.md">了解申请流程</a>
+</section>

--- a/docs/people.en.md
+++ b/docs/people.en.md
@@ -1,2 +1,49 @@
 # People
-PI and members will be listed here.
+
+## Principal Investigator
+**Assoc. Prof. Jiazhou Chen**  
+Tenure-track associate professor and doctoral advisor at the School of Computer Science, Guangdong University of Technology. He leads the Bioinformatics & Brain Science Lab with research spanning biomedical data intelligence, brain network modeling, and multimodal learning, and serves as PI for national key R&D and National Natural Science Foundation projects.
+
+- Email: [csjzchen@gdut.edu.cn](mailto:csjzchen@gdut.edu.cn)
+- Phone: (+86) 188-2411-9115
+- Faculty profile: [GDUT School of Computer Science](https://cs.gdut.edu.cn/info/2241/4707.htm)
+
+## Members
+
+<details class="member-card">
+<summary><strong>Jiazhou Chen</strong> · Associate Professor, School of Computer Science, GDUT</summary>
+
+- **Research Interests**: Biomedical data intelligence, complex biological network analysis, bioinformatics, brain science
+- **Education**:
+  1. Sep 2016 – Dec 2020 · Ph.D. in Computer Science and Technology, South China University of Technology (Advisor: Guoqiang Han)
+  2. Sep 2013 – Jun 2016 · M.Eng. in Software Engineering, Guangdong University of Technology (Advisor: Bi Zeng)
+  3. Sep 2009 – Jun 2013 · B.Eng. in Computer Science and Technology, Jiaying University
+- **Professional Experience**:
+  1. Jun 2024 – Present · Associate Professor, School of Computer Science, GDUT
+  2. Jan 2021 – May 2024 · Postdoctoral Research Fellow, School of Computer Science and Engineering, SCUT (Co-advisor: Hongmin Cai)
+  3. Sep 2019 – Sep 2020 · Visiting Scholar, University of North Carolina at Chapel Hill, USA (Host: Guorong Wu)
+
+#### Selected Publications (First/Corresponding Author)
+1. Fei Qi, Jin Guo, et al. "Multi-Kernel Clustering with Tensor Fusion on Grassmann Manifold for High-dimensional Genomic Data," *Methods*, 2024.
+2. Xiaoqi Sheng, Hongmin Cai, et al. "Modality-Aware Discriminative Fusion Network for Integrated Analysis of Brain Imaging Genomics," *IEEE Transactions on Neural Networks and Learning Systems*, 2024.
+3. Hongmin Cai, Ranran Deng, et al. "Harmonic Wavelet Neural Network for Discovering Neuropathological Propagation Patterns in Alzheimer’s Disease," *IEEE Journal of Biomedical and Health Informatics*, 2024.
+4. Hongmin Cai, Xiaoqi Sheng, et al. "Brain Network Classification via Manifold Harmonic Discriminant Analysis," *IEEE Transactions on Neural Networks and Learning Systems*, 2023.
+
+#### Honors & Awards (Selected)
+- 2025 · First Prize, Guangdong Science and Technology Progress Award (Rank 5)
+- 2023 · Rising Star Award, ACM SIGBIO China (Rank 1)
+- 2022 · First Prize (Natural Science), Guangdong Association of Artificial Intelligence Industry (Rank 3)
+- 2021 · Outstanding Ph.D. Thesis Award, ACM SIGBIO China (Rank 1)
+
+#### Funded Projects (PI)
+- NSFC General Program (2026–2029): Graph computing for spatial multi-omics data generation and integration
+- National Key R&D Program Task (2024–2027): Generative algorithms for subcellular-precision multi-omics digital twin cells
+- NSFC Young Scientists Fund (2022–2024): Harmonic brain networks for early diagnosis of Alzheimer’s disease
+
+#### Professional Service
+- Reviewer for IEEE TMI, IEEE JBHI, IEEE TNNLS, Briefings in Bioinformatics, among others
+- Executive committee member, CAAI Bioinformatics & Artificial Life Society
+- Executive committee member, CCF Bioinformatics Technical Committee
+</details>
+
+> Add member profiles and photos in `docs/assets/people/` as they become available.

--- a/docs/people.zh.md
+++ b/docs/people.zh.md
@@ -1,15 +1,172 @@
 # 团队（Team）
 
 ## 负责人 Principal Investigator
-**陈佳洲 教授**  
-广东工业大学“百人计划”特聘教授，博士生导师。  
-广东省“珠江人才计划”青年拔尖人才，广东省自然科学基金杰出青年项目获得者等。  
-研究方向：生物信息学与系统生物学、脑科学与神经生物学、基因表达调控与疾病机制、蛋白质结构与功能预测、基因组学与转录组学数据分析。
+**陈佳洲 副教授**
+广东工业大学计算机学院“百人计划”特聘副教授，博士生导师，生物信息学与脑科学课题组负责人。长期从事生物医学数据智能分析、脑网络建模
+与多模态学习研究，主持国家重点研发计划与国家自然科学基金等项目。
 
-- 邮箱：`example@gdut.edu.cn`  
-- 学术主页：[*Google Scholar*](#) · ORCID: [0000-0000-0000-0000](#)
+- 邮箱：[csjzchen@gdut.edu.cn](mailto:csjzchen@gdut.edu.cn)
+- 手机：(+86) 188-2411-9115
+- 学术主页：[广东工业大学计算机学院](https://cs.gdut.edu.cn/info/2241/4707.htm)
 
 ## 成员 Members
-> 将照片放入 `docs/assets/people/`，在此添加条目。
 
-- 博士生 / 硕士生 / 本科生 ……
+<details class="member-card">
+<summary><strong>陈佳洲</strong> · 副教授，广东工业大学计算机学院</summary>
+
+**陈佳洲个人简历（精选）**
+
+- **职称**：博士、副教授
+- **任职单位**：广东工业大学计算机学院
+- **Email**：[csjzchen@gdut.edu.cn](mailto:csjzchen@gdut.edu.cn)
+- **手机**：(+86) 188-2411-9115
+
+**一、教育背景**
+1. 2016年09月–2020年12月：华南理工大学（华工），广州，中国，工学博士（计算机科学与技术），导师：韩国强
+2. 2013年09月–2016年06月：广东工业大学（广工），广州，中国，工学硕士（软件工程），导师：曾碧
+3. 2009年09月–2013年06月：嘉应学院（嘉大），梅州，中国，工学学士（计算机科学与技术）
+
+**二、工作经历**
+1. 2024年06月－至今：广东工业大学（广工），计算机学院，副教授
+2. 2021年01月－2024年05月：华南理工大学（华工），计算机科学与工程学院，博士后，导师：蔡宏民
+3. 2019年09月－2020年09月：University of North Carolina at Chapel Hill（UNC），北卡罗来纳大学教堂山分校，美国，访问学者，导师：吴国荣
+
+**三、研究兴趣**
+- 生物医学数据智能分析
+- 复杂生物网络分析
+- 生物信息学
+- 脑科学
+
+**四、发表著作**
+（*为通讯作者，#为并列第一作者，谷歌引用831次，H指数16）
+
+**（一）期刊论文（第一作者/通讯作者）**
+1. Fei Qi, Jin Guo, Junyu Li, Liao Yi, Liao Wenxiong, Hongmin Cai, Jiazhou Chen*. Multi-Kernel Clustering with Tensor Fusion on Grassmann Manifold for High-dimensional Genomic Data[J]. Methods, 2024, 231:215-225. (中科院3区，JCR 2区，影响因子4.3)
+2. Xiaoqi Sheng, Hongmin Cai, Nie Yongwei, He Shengfeng, Yiu-Ming Cheung, Jiazhou Chen*. Modality-Aware Discriminative Fusion Network for Integrated Analysis of Brain Imaging Genomics[J]. IEEE Transactions on Neural Networks and Learning Systems, 2024, DOI: 10.1109/TNNLS.2024.3439530. (中科院1区，JCR 1区，影响因子14.255，TOP)
+3. Hongmin Cai, Ranran Deng, Defu Yang, Fa Zhang, Guorong Wu, and Jiazhou Chen*. Harmonic wavelet neural network for discovering neuropathological propagation patterns in Alzheimer’s disease [J]. IEEE Journal of Biomedical and Health Informatics, 2024, doi: 10.1109/JBHI.2024.3434394. (中科院2区，JCR 1区，影响因子7.021，TOP)
+4. Hongmin Cai, Xiaoqi Sheng, Guorong Wu, Bin Hu, Yiu-Ming Cheung, Jiazhou Chen*. Brain network classification for accurate detection of Alzheimer’s disease via manifold harmonic discriminant analysis[J]. IEEE Transactions on Neural Networks and Learning Systems, 2023, DOI: 10.1109/TNNLS.2023.3301456. (中科院1区，JCR 1区，影响因子14.255，TOP)
+5. Huan Liu, Hongmin Cai, Defu Yang, Wentao Zhu, Guorong Wu, Jiazhou Chen*. Learning pyramidal multi-scale harmonic wavelets for identifying the neuropathology propagation patterns of Alzheimer’s disease[J]. Medical Image Analysis, 2023, 87: 102812. (中科院1区，JCR 1区，影响因子13.828，TOP)
+6. Hongmin Cai, Huan Liu, Defu Yang, Guorong Wu, Bin Hu, Jiazhou Chen*. Estimating outlier-immunized common harmonic waves for brain network analyses on the stiefel manifold[J]. IEEE Journal of Biomedical and Health Informatics, 2023, 27(5):2411-2422. (中科院2区，JCR 1区，影响因子7.021，TOP)
+7. Jiazhou Chen, Jie Huang, Yi Liao, Lei Zhu, and Hongmin Cai. Identify multiple gene-drug common modules via constrained graph matching [J], IEEE Journal of Biomedical and Health Informatics, 2022, 26(9): 4794-4805. (中科院2区，JCR 1区，影响因子7.021，TOP)
+8. Jiazhou Chen, Hongmin Cai, Defu Yang, Martin Styner, Guorong Wu*. Characterizing the propagation pathway of neuropathological events of Alzheimer's disease using harmonic wavelet analysis [J], Medical Image Analysis, 2022, 79: 102446 (中科院1区，JCR 1区，影响因子13.828，TOP)
+9. Jiazhou Chen, Guoqiang Han, Aodan Xu, Tatsuya Akutsu, Hongmin Cai*. Identifying miRNA-gene common and specific regulatory modules for cancer subtyping by a high-order graph matching model [J], IEEE/ACM Transactions on Computational Biology and Bioinformatics, 2022, 20(1): 421-431. (中科院3区，JCR 2区，影响因子3.710)
+10. Jiazhou Chen, Wentao Rong, Guihua Tao, and Hongmin Cai*. Similarity Fusion via Exploiting High Order Proximity for Cancer Subtyping [J], IEEE/ACM Transactions on Computational Biology and Bioinformatics, 2021, 20(1): 658 - 667. （中科院3区，JCR 2区，影响因子3.710）
+11. Jiazhou Chen, Guoqiang Han, et al. Learning common harmonic waves on stiefel manifold – A new mathematical approach for brain network analyses [J], IEEE Transactions on Medical Imaging, 2020, 40(1):419-430.（中科院1区，JCR 1区，影响因子11.037，TOP）
+12. Jie Huang#, Jiazhou Chen#, et al. Evaluation of gene-drug common Module Identification methods using Pharmacogenomics data [J], Briefings in Bioinformatics, 2021, 22(3): bbaa087. （中科院2区，JCR 1区，影响因子13.994，TOP）
+13. Jiazhou Chen, Guoqiang Han, Hongmin Cai*, etc. Identification of multidimensional regulatory modules through multi-graph matching with network constraints[J]. IEEE Transactions on Biomedical Engineering, 2020, 67(4): 987-998. （中科院2区，JCR 1区，影响因子4.756）
+14. Jiazhou Chen, Hong Peng, Guoqiang Han, Hongmin Cai*, etc. HOGMMNC: a higher order graph matching with multiple network constraints model for gene-drug regulatory modules identification[J], Bioinformatics, 2019, 35(4): 602-610. （中科院3区，JCR 1区，影响因子6.937）
+15. 陈佳洲, 曾碧, 何元烈. 一种应用于静态图像人体分割的显著性检测方法[J].小型微型计算机系统,2016,37(3):608-611. （中文核心）
+16. 陈佳洲, 曾碧, 何元烈. 基于模糊控制的LED舞台灯自适应调节系统[J]. 计算机应用与软件,2016,33(4):84-87.（中文核心）
+
+**（二）会议论文（第一作者/通讯作者）**
+1. Fei Qi, Junyu Li, Yi Liao, Wenxiong Liao, Jiazhou Chen*, Hongmin Cai. Multi-Kernel Tensor Fusion on Grassmann Manifold for Genomic Data Clustering [C], IEEE International Conference on Bioinformatics and Biomedicine (BIBM), 2023 December 5-8, 2023, Istanbul, Turkey. (CCF B)
+2. Hongmin Cai, Zhixuan Zhou, Defu Yang, Guorong Wu, and Jiazhou Chen*. Discovering Brain Network Dysfunction in Alzheimer's Disease Using Brain Hypergraph Neural Network [C], International Conference on Medical Image Computing and Computer Assisted Intervention – MICCAI 2023, Vancouver, Canada, 2023-10-08 to 2023-10-12.(CCF B)
+3. Jiazhou Chen, Defu Yang, et al. Discovering Spreading Pathways of Neuropathological Events in Alzheimer’s Disease Using Harmonic Wavelets [C], The 27th international conference on Information Processing in Medical Imaging- IPMI 2021, Bornholm, Denmark, 2021-06-27 to 2021-07-02. (Medical image conference)
+4. Jiazhou Chen, Guoqiang Han, et al. Estimating common harmonic waves of brain networks on stiefel manifold [C], International Conference on Medical Image Computing and Computer Assisted Intervention – MICCAI 2020, Lima, Peru, 2020-10-04 to 2020-10-08. (CCF B)
+
+**（三）期刊论文（合著）**
+1. Bin Zhang, Yue Zhang, Junyu Li, Jiazhou Chen, Tatsuya Akutsu, Yiu-ming Cheung, Hongmin Cai. Unsupervised Dual Deep Hashing with Semantic-Index and Content-Code for Cross-Modal Retrieval[J]. IEEE Transactions on Pattern Analysis and Machine Intelligence, 2024, DOI: 10.1109/TPAMI.2024.3467130.（中科院1区，JCR 1区，影响因子24.314, TOP）
+2. Hongmin Cai , Bin Zhang , Junyu Li , Bin Hu , Jiazhou Chen. Unsupervised Dual Hashing Coding (UDC) on Semantic Tagging and Sample Content for Cross-modal Retrieval[J]. IEEE Transactions on Multimedia, 2024, 26:9109 - 9120（中科院1区，JCR 1区，影响因子9.7, TOP）
+3. Yue Zhang, Xin Sun, Hongmin Cai, Haiyan Wang, Jiazhou Chen, Endai Guo, Fei Qi, Junyu Li. Collaborative Embedding Learning via Tensor Integration for Multi-view Clustering[J]. IEEE Transactions on Emerging Topics in Computational Intelligence, 2024, 8(2):1841-1852（中科院2区，JCR 1区，影响因子5.3）
+4. Tingting Dan, Xijie Chen, Miao He, Hongmei Guo, Xiaoqin He, Jiazhou Chen, et al. DeepGA for automatically estimating fetal gestational age through ultrasound imaging[J]. Artificial Intelligence in Medicine, 2023, 135: 102453.（中科院2区，JCR 1区，影响因子7.011，TOP）
+5. Sheng Xiaoqi, Chen Jiazhou, Yong Liu, Bin Hu, Hongmin Cai. Deep manifold harmonic network with dual attention for brain disorder classification[J]. IEEE Journal of Biomedical and Health Informatics, 2022, 27(1): 131-142. (中科院2区，JCR 1区，影响因子7.021，TOP)
+6. Zhichao Zhou, Yu Hu, Yue Zhang, Jiazhou Chen, Hongmin Cai. Multi-view deep graph infomax to achieve unsupervised graph embedding[J]. IEEE Transactions on Cybernetics, 2022, 53(10):6329-6339.（中科院1区，JCR 1区，影响因子19.118，TOP）
+7. Junyu Li, Jiazhou Chen, Fei Qi, Tingting Dan, Wanlin Weng, Bin Zhang, Haoliang Yuan, Hongmin Cai, Cheng Zhong. Two-dimensional unsupervised feature selection via sparse feature filter [J]. IEEE Transactions on Cybernetics, 2022, 53(9):5605-5617.（中科院1区，JCR 1区，影响因子19.118，TOP）
+8. Guihua Tao, Haojiang Li, Jiabin Huang, Chu Han, Jiazhou Chen, Guangying Ruan, Wenjie Huang, Yu Hu, Tingting Dan, Bin Zhang, Shengfeng He, Lizhi Liu, Hongmin Cai. SeqSeg: A sequential method to achieve nasopharyngeal carcinoma segmentation free from background dominance [J]. Medical Image Analysis, 2022, 78:102381. (中科院1区，JCR 1区，影响因子13.828，TOP)
+9. Yang Li, Tingting Dan, Haojiang Li, Jiazhou Chen, Hong Peng, Lizhi Liu, Hongmin Cai. NPCNet: Jointly segment primary nasopharyngeal carcinoma tumors and metastatic lymph nodes in MR images[J]. IEEE Transactions on Medical Imaging, 2022, 41(7):1639-1650（中科院1区，JCR 1区，影响因子11.037，TOP）
+10. Defu Yang, Jiazhou Chen, et al. Group-wise hub identification by learning common graph embeddings on grassmannian manifold[J]. IEEE Transactions on Pattern Analysis and Machine Intelligence, 2021. DOI: 10.1109/TPAMI.2021.3081744（中科院1区，JCR 1区，影响因子24.314, TOP）
+11. Haiyan Wang, Guoqiang Han, Junyu Li, Bin Zhang, Jiazhou Chen, Yu Hu, Chu Han, Hongmin Cai*, Learning task-driving affinity matrix for accurate multi-view clustering through tensor subspace learning, Information Sciences, 2021.（中科院1区，JCR 1区，影响因子 8.233，TOP）
+12. Hong Peng, Yu Hu, Jiazhou Chen, et al. Integrating tensor similarity to enhance clustering performance[J]. IEEE Transactions on Pattern Analysis and Machine Intelligence, 2020. DOI: 10.1109/TPAMI.2020.3040306. （中科院1区，JCR 1区，影响因子24.314, TOP）
+13. Bin Zhang, Hongmin Cai, Jiazhou Chen, et al. Fast and accurate clustering of multiple modality data via feature matching [J]. IEEE Transactions on Cybernetics, 2020. DOI: 10.1109/TCYB.2020.3026396. （中科院1区，JCR 1区，影响因子19.118，TOP）
+14. Wentao Rong, Enhong Zhuo, Hong Peng, Jiazhou Chen, et al. Learning a consensus affinity matrix for multi-view clustering via subspaces merging on Grassmann manifold[J]. Information Sciences ,2020, 547: 68-87. （中科院1区，JCR 1区，影响因子 8.233，TOP）
+15. Zhuohui Wei, Yue Zhang, Wanlin Weng, Jiazhou Chen, et al. Survey and comparative assessments of computational multi-omics integrative methods with multiple regulatory networks identifying distinct tumor compositions across pan-cancer data sets[J]. Briefings in Bioinformatics, 2020. DOI: 10.1093/bib/bbaa102. （中科院2区，JCR 1区，影响因子13.994，TOP）
+16. Wanlin Weng, Weiwei Zhou, Jiazhou Chen, et al. Enhancing multi-view clustering through common subspace integration by considering both global similarities and local structures[J]. Neurocomputing, 2020, 378: 375-386. （中科院2区，JCR 1区，影响因子5.779）
+17. Aodan Xu, Jiazhou Chen, Hong Peng, et al. Simultaneous interrogation of cancer omics to identify subtypes with significant clinical differences[J]. Frontiers in Genetics, 2019, 10: 236. （中科院3区，JCR 1区，影响因子4.772）
+18. Hongmin Cai, Qinjian Huang, ..., Jiazhou Chen, et al. Breast microcalcification diagnosis using deep convolutional neural network from digital mammograms[J]. Computational and Mathematical Methods in Medicine, 2019. 2019: 2717454. （中科院4区，JCR 2区，影响因子2.238）
+19. Xi Yang, Guoqiang Han, Jiazhou Chen, Hongmin Cai*. Finding correlated patterns via high-order matching for multiple sourced biological data[J]. IEEE Transactions on Biomedical Engineering, 2019, 66(4): 1017-1025. （中科院2区，JCR 1区，影响因子4.756）
+20. Jiulun Cai, Hongmin Cai*, Jiazhou Chen, Xi, Yang. "Many-to-Many" Relationships Between Gene-Expression Data and Drug-Response Data Via Sparse Binary Matching[J], IEEE/ACM Transactions on Computational Biology and Bioinformatics, 2018:1-10. （中科院3区，JCR 1区，影响因子3.710）
+21. Yuan You, Hongmin Cai*, Jiazhou Chen. Low rank representation and Its application in bioinformatics[J]. Current Bioinformatics, 2018, 13(5): 508-517. （中科院4区，JCR 3区，影响因子3.543）
+22. Hongmin Cai, Peihua Chen, Jiazhou Chen, etc. WaveDec: A wavelet approach to identify both shared and individual patterns of copy-number variations[J], IEEE Transactions on Biomedical Engineering, 2017, 99: 1-13. （中科院2区，JCR 1区，影响因子4.756）
+
+**（四）会议论文（合著）**
+1. Ye Liu, Xiaojie Wang, Hongshan Pu, Jiazhou Chen, and Hongmin Cai. Module-level Gene-drug Interaction Identification via Hierarchical Optimal Transport [C]. The IEEE International Conference on Bioinformatics and Biomedicine (BIBM), 2024. (CCF B)
+2. Haiyan Wang, Jiazhou Chen, Bin Zhang, and Hongmin Cai. Accurate multi-view clustering by exploiting within-view high-order affinities through tensor self-representation [C]. The IEEE International Conference on Bioinformatics and Biomedicine (BIBM), 2022. (CCF B)
+3. Zhuobin Huang, Tingting Dan, Yi Lin, Jiazhou Chen, Hongmin Cai, and Guorong Wu. Detecting brain state changes via manifold mean shifting [C]. The IEEE International Conference on Bioinformatics and Biomedicine (BIBM), 2021. (CCF B)
+4. Haiyan Wang, Guoqiang Han, Yu Hu, Hong Peng, Jiazhou Chen. Multi-view tensor clustering through exploiting both within-view and across-view high-order correlations[C]//2021 IEEE International Conference on Multimedia and Expo (ICME). IEEE, 2021: 1-6. (CCF B)
+5. Junbo Ma, Xiaofeng Zhu, Defu Yang, Jiazhou Chen, Guorong Wu. Attention-guided deep graph neural network for longitudinal Alzheimer’s disease analysis[C]. International Conference on Medical Image Computing and Computer Assisted Intervention – MICCAI 2020, Lima, Peru, 2020-10-04 to 2020-10-08. (CCF B)
+
+**五、发明专利**
+1. 一种基于深度神经网络的脑部图像处理方法及系统，2024.03.13，中国，2024102864990，排名3/3(蔡宏民，邓冉冉，陈佳洲)
+2. 基于流形学习的脑网络多尺度小波分析方法、装置及介质，2023.04.20，中国，202310432896X，排名1/3 (陈佳洲，蔡宏民，刘欢)
+3. 一种室内场景物体同时识别与建模方法, 2019.07.19/2016.9.19，中国， ZL201610832845.6，排名2/4 (曾碧，陈佳洲，黄文，曹军)
+4. 一种应用于静态图像人体分割的显著性检测方法, 2017.12.26/2015.07.29，中国，ZL201510460130.8，排名3/4 (曾碧，何元烈，陈佳洲，马晓东)
+5. 一种鼻咽癌人工智能辅助诊疗决策终端，2018.01.18，中国，ZL201810047306.0，排名4/6 (陈明远，蔡宏民，刘友平，陈佳洲，邹雄，游瑞)
+6. 一种鼻咽癌数据库及基于所述数据库的综合诊疗决策方法，2018.01.18，中国，ZL201810047144.0，排名4/6 (陈明远，蔡宏民，刘友平，陈佳洲，邹雄，游瑞)
+7. 一种基于神经网络的数据库数据综合诊疗决策方法，2018.01.18，中国，ZL201810047166.7， 排名4/6 (陈明远，蔡宏民，刘友平，陈佳洲，邹雄，游瑞)
+8. 鼻咽癌数据库及基于所述数据库的综合诊疗决策方法，2018.01.18，中国，ZL201810047223.1，排名4/6 (陈明远，蔡宏民，刘友平，陈佳洲，邹雄，游瑞)
+
+**六、软件著作权**
+- LED灯自适应控制系统，2014，中国，2015SR003702， 排名3（曾碧，何元烈，陈佳洲）
+
+**七、荣誉及奖励**
+1. 广东省科技进步一等奖，省级，排名5，广东省科技厅，2025
+2. ACM SIGBIO China分会新星奖，国家级，排名1，ACM SIGBIO China分会，2023
+3. 广东省计算机学会优秀论文二等奖，省级，排名1，广东省计算机学会，2023
+4. 广东省人工智能产业协会科学技术奖自然科学奖一等奖（“超高维小样本无监督学习及其在生物医学领域的应用”），省级，排名3，广东省人工智能产业协会，2022
+5. ACM SIGBIO China分会优博奖，国家级，排名1，ACM SIGBIO China分会，2021
+6. 国家公派出国留学资格，国家级，排名1，国家留学基金管理委员会，2019
+7. 华南理工大学校长奖学金，校级，排名1，华南理工大学，2019
+8. 广东省计算机学会优秀论文二等奖，省级，排名1，广东省计算机学会，2018
+9. 国家奖学金，国家级，排名1，中华人民共和国教育部，2015
+10. 广东工业大学一等奖学金，校级，排名1，广东工业大学，2015
+11. 连续两年获得广东省机器人大赛二等奖，省级，排名2&3，广东省计算机学会， 2013/2014
+12. 连续三年获得嘉应学院二等奖学金，校级，排名1，嘉应学院，2010/2011/2012
+
+**八、主持或参与项目**
+**（一）主持项目**
+1. 国家自然科学基金面上项目，62572130，基于图计算的空间多组学数据生成和整合研究，2026-01-01至2029-12-31，50万元，在研
+2. 国家重点研发计划课题，2024YFF1206603，基于生成式算法的亚细胞精度多组学数字孪生细胞技术，2024-12至2027-11，294.11万元，在研
+3. 第16批博士后特别资助（站中）项目，2023T160226，面向脑疾病的多尺度脑网络小波分析理论和应用研究，2023-01 至 2024-01，18万元，结题
+4. 广东省自然科学基金-面上项目，2022A1515011162，多源异构生物医学大数据融合方法研究及应用，2022-01-01 至 2024-12-31，10万元，结题
+5. 国家自然科学基金青年项目，62102153，基于脑网络谐波的阿尔茨海默症早期诊断分析理论和应用研究，2022-01-01 至 2024-12-31，30万元，结题
+6. 第69批博士后面上项目，2021M691062，基于多源异构大数据的阿尔茨海默症早期诊断分析理论和应用，2021-05 至 2023-05，8万元，结题
+7. 2018年秋季华南理工大学优秀博士学位论文创新基金，图匹配在多源异构多组学数据共表达模块查找中的研究，2018-2019年，3.6万，结题
+8. 华南理工大学计算机学院自然科学基金，2018-2019年，1万，结题
+
+**（二）参与项目**
+1. 国家自然科学基金面上项目，62272326，基于多模态CRC数据融合的临床决策分析模型及临床应用，2023-01-01 至 2026-12-31，53万元，华工到账15.3万，在研
+2. 广州市重点研发计划项目，202206030009，多源异构数据和跨域知识聚合关键技术研究及其示范应用，2022-2025年，500万，在研
+3. 广东省国际科技合作项目，多尺度生物信息学数据整合分析理论及人工智能辅助诊断产业应用，2022.01.01-2024.01.01, 200万，结题
+4. 国家重点研发计划政府间重点专项项目，SQ2021YFE010946，多尺度生物信息学数据整合分析理论和应用研究，2021-01-01至2024-12-31，300万，结题
+5. 国家自然科学基金联合基金项目，U21A20520，面向脑疾病的多模态医学影像智能分析方法，2022-01-01 至 2025-12-31，260万元，在研，第二参与人
+6. 国家自然科学基金面上项目，62172112，面向多组学数据的深度聚类理论和应用研究，2022- 01-01 至 2025-12-31，61万元，在研
+7. 国家自然科学基金面上项目，82171075，基于视网膜影像和蛋白组学特征关联网络的糖尿病黄斑水肿机制和疗效预测研究 ，2022-01-01 至 2025-12-31，57万元，在研
+8. 国家自然科学基金面上项目，61771007，面向多源异构海量生物信息大数据的局部公共模式发现理论和应用，2018-01-01 至 2021-12-31，50万元，结题
+9. 广州市民生科技攻关计划项目，201803010021，鼻咽癌大数据云端诊疗分析系统，2018-04 至 2021-03，200万元，结题
+
+**九、学术任职**
+**（一）审稿人**
+IEEE Transactions on Medical Imaging (TMI), IEEE Journal of Biomedical and Health Informatics (JBHI), IEEE Transactions on Neural Networks and Learning Systems (TNNLS), Briefing in Bioinformatics (BIB), Bioinformatics, Pattern Recognition, Scientific Reports, Frontiers in Genetics, Frontiers in Bioinformatics, Interdisciplinary Sciences - Computational Life Sciences, Brain Communications, eBioMedicine, IPMI, MICCAI.
+
+**（二）专业任职**
+1. 中国人工智能学会生物信息学与人工生命专业委员会执行委员
+2. 中国计算机学会生物信息学专业委员会执行委员
+3. 全国计算机学会生物信息学“新未来”青年学者研讨会（BIO-3NEW）执行委员
+4. 广东省生物医学工程学会智能医学影像分会委员
+5. 广东省医师协会人工智能临床应用专委会委员
+6. Frontiers in Genetics Review Editor
+7. International Conference on Bioinformatics and Biomedicine (BIBM) 2022/2023/2024/2025, PC member
+
+**十、特邀报告**
+1. 2025.08.21：“面向生物网络数据的图计算关键技术”，生物信息学与智能信息处理2025年学术年会，中国，深圳，2025年8月21-23日
+2. 2025.03.28：“面向生物网络数据的图计算关键技术”，第二届全国基因组信息学大会，中国，深圳，2025年03月28-30日
+3. 2024.08.09：“基于图模型的生物网络智能解析和整合”，第九届中国计算机学会生物信息学会议，中国，长春，2024年08月09-11日
+4. 2022.08.09：“Learning Pyramidal Multi-scale Harmonic Wavelets for Identifying the Neuropathology Propagation Patterns of Alzheimer’s Disease”, The 2st International Workshop on Mathematical Methods for Analyzing Biological Data, ICIC 2022, China, Xi’an, August 7-11, 2022
+5. 2021.08.13：“Identifying Spatial-spectrum Alteration of Brain Network in Alzheimer’s Disease Using Harmonic Wavelets”, The 1st International Workshop on Mathematical Methods for Analyzing Biological Data, ICIC 2021, China, Shenzhen,  August,12-15,2021
+6. 2021.05.21：“基于流形学习的脑网络公共谐波分析方法”，生物信息学与智能信息处理2021学术年会，中国，武汉，2021年05月21-23日
+7. 2016.11.12：“Low Rank Representation and Its Application in Bioinformatics”，第一届计算机学会生物信息学会议，中国，重庆，2016年11月12-14日
+8. 2014.12.12：一种应用于静态图像人体分割的显著性检测方法，2014广东省机器人大赛暨机器人技术研讨会，中国，广州，2014年12月12-13日
+
+</details>
+
+> 将照片放入 `docs/assets/people/`，在此添加更多团队成员。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: 广东工业大学 生物信息学与脑科学课题组
 site_url: https://mark7399.github.io/lab-site/
 theme:
   name: material
+  logo: assets/gdut-logo.svg
   features:
     - navigation.tabs
     - navigation.instant
@@ -11,8 +12,16 @@ theme:
     - toc.integrate
     - navigation.footer
   language: zh
-  icon:
-    logo: material/brain
+  palette:
+    - scheme: default
+      primary: white
+      accent: deep purple
+    - scheme: slate
+      primary: indigo
+      accent: pink
+      toggle:
+        icon: material/weather-night
+        name: 夜间模式
 
 plugins:
   - search
@@ -24,20 +33,34 @@ plugins:
         - locale: zh
           default: true
           name: 中文
+          nav:
+            - HOME: index.zh.md
+            - RESEARCH:
+              - Overview: research.zh.md
+              - Platforms & Software: projects.zh.md
+            - NEWS: news.zh.md
+            - PUBLICATIONS: publications.zh.md
+            - MEMBERS:
+              - Team: people.zh.md
+            - JOIN US:
+              - Opportunities: contact.zh.md
+              - Resources: downloads.zh.md
         - locale: en
           name: English
+          nav:
+            - HOME: index.en.md
+            - RESEARCH:
+              - Overview: research.en.md
+              - Platforms & Software: projects.en.md
+            - NEWS: news.en.md
+            - PUBLICATIONS: publications.en.md
+            - MEMBERS:
+              - Team: people.en.md
+            - JOIN US:
+              - Opportunities: contact.en.md
+              - Resources: downloads.en.md
   - git-revision-date-localized:
       fallback_to_build_date: true
-
-nav:
-  - 首页: index.zh.md
-  - 团队: people.zh.md
-  - 科研方向: research.zh.md
-  - 论文成果: publications.zh.md
-  - 项目&软件: projects.zh.md
-  - 新闻: news.zh.md
-  - 资源下载: downloads.zh.md
-  - 联系方式: contact.zh.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary
- replace the Chinese member card for Jiazhou Chen with the curated CV text highlighting his education, experience, research interests, publications, patents, honors, projects, professional service, and invited talks

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c96340bae88333bafdc63f601a56ac