### PR TITLE
Polish publications page presentation

### DIFF
--- a/docs/assets/publications.js
+++ b/docs/assets/publications.js
@@ -1,0 +1,44 @@
+(function () {
+  const enhanceBibliography = () => {
+    const heading = document.querySelector('.md-typeset h1#publications');
+    if (!heading) {
+      return;
+    }
+
+    document
+      .querySelectorAll('.md-typeset .footnote ol > li > p')
+      .forEach((paragraph) => {
+        if (paragraph.classList.contains('pub-enhanced')) {
+          return;
+        }
+        if (paragraph.querySelector('.publication-title')) {
+          paragraph.classList.add('pub-enhanced');
+          return;
+        }
+
+        const html = paragraph.innerHTML.trim();
+        const match = html.match(/^(\s*[\s\S]*?\.\s+)([\s\S]*?\.)(\s*)(<[\s\S]*)$/);
+        if (!match) {
+          return;
+        }
+
+        const [, authorsPart, titlePart, spacer, remainder] = match;
+        if (!titlePart.trim()) {
+          return;
+        }
+
+        paragraph.innerHTML = `${authorsPart}<span class="publication-title">${titlePart}</span>${spacer}${remainder}`;
+        paragraph.classList.add('pub-enhanced');
+      });
+  };
+
+  const runEnhancement = () => {
+    window.requestAnimationFrame(enhanceBibliography);
+  };
+
+  if (typeof document$ !== 'undefined' && document$.subscribe) {
+    document$.subscribe(runEnhancement);
+  } else {
+    document.addEventListener('DOMContentLoaded', runEnhancement);
+  }
+})();

--- a/docs/assets/ux.css
+++ b/docs/assets/ux.css
@@ -435,3 +435,20 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Publications styling */
+.md-typeset .footnote ol > li > p {
+  line-height: 1.7;
+}
+
+.md-typeset .publication-title {
+  display: inline-block;
+  margin: 0.1em 0;
+  font-size: 1.1em;
+  font-weight: 600;
+  color: var(--lab-ink);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .publication-title {
+  color: rgba(255, 255, 255, 0.92);
+}

--- a/docs/publications.en.md
+++ b/docs/publications.en.md
@@ -1,2 +1,3 @@
 # Publications
-{% bibliography %}
+
+\full_bibliography

--- a/docs/publications.zh.md
+++ b/docs/publications.zh.md
@@ -1,6 +1,3 @@
 # 论文成果 Publications
 
-!!! info "维护方式"
-    将 BibTeX 文献条目粘贴到 `docs/assets/refs.bib`，此页面会自动渲染。
-
-{% bibliography %}
+\full_bibliography

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,3 +80,5 @@ markdown_extensions:
 
 extra_css:
   - assets/ux.css
+extra_javascript:
+  - assets/publications.js


### PR DESCRIPTION
## Summary
- remove the maintenance notice from the Chinese publications page now that the bibliography renders automatically
- add client-side enhancement and styling so publication titles are emphasized with a larger font across both locales

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68cad67f221c8333bb040b0cc64e5c88